### PR TITLE
Add HMCTS deploy user public ssh key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version 0.0.1
+
+Initial version adding HMCTS deploy user ssh public key

--- a/hmcts-base/init.sls
+++ b/hmcts-base/init.sls
@@ -4,3 +4,5 @@ hmcts-deploy-key:
     - enc: ecdsa-sha2-nistp521
     - comment: "HMCTS deploy key"
     - name: "AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAHFcljkX7bBct4pdhleZKb9OytcxCZbIQwSPIEvadYoAHbiw8eWDzp0dTBApPTNJHqeNSY6fPMgl6YdyzuuQ0OgeADMgTIuop/SHYVlySoAgPP/k3tnDbfjDvXq8rVSGMe/YHwYtjHFW52UULeE8B9Aogsml5cAsTOZseNbiAU43goL6Q=="
+    - require:
+      - user: deploy-user

--- a/hmcts-base/init.sls
+++ b/hmcts-base/init.sls
@@ -1,0 +1,6 @@
+hmcts-deploy-key:
+  ssh_auth.present:
+    - user: deploy
+    - enc: ecdsa-sha2-nistp521
+    - comment: "HMCTS deploy key"
+    - name: "AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAHFcljkX7bBct4pdhleZKb9OytcxCZbIQwSPIEvadYoAHbiw8eWDzp0dTBApPTNJHqeNSY6fPMgl6YdyzuuQ0OgeADMgTIuop/SHYVlySoAgPP/k3tnDbfjDvXq8rVSGMe/YHwYtjHFW52UULeE8B9Aogsml5cAsTOZseNbiAU43goL6Q=="

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - git@github.com:ministryofjustice/moj-docker-deploy-formula.git


### PR DESCRIPTION
When the products were carved off for HMCTS a new deploy user and key
were created to avoid sharing the main MoJD deploy user's key. This
change installs that key with Salt so that we don't have to
manually install it when machines get recycled.